### PR TITLE
Fix/table visibility

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+src
+docs
+.github

--- a/src/components/table/index.tsx
+++ b/src/components/table/index.tsx
@@ -58,6 +58,7 @@ export type ColumnProps<
     TValue = unknown,
     TError extends HttpError = HttpError,
 > = {
+    id: string;
     accessorKey: string;
     enableSorting?: boolean;
     enableHiding?: boolean;
@@ -92,6 +93,7 @@ export function Table<
 >({ children, table, showHeader = true }: TableProps<TData, TError>) {
     const mapColumn = useCallback(
         ({
+            id,
             accessorKey,
             header,
             enableSorting,
@@ -100,7 +102,7 @@ export function Table<
             cell,
         }: ColumnProps<TData, TError>): ColumnDef<TData, unknown> => {
             const column: any = {
-                id: accessorKey,
+                id,
                 header,
                 accessorKey,
                 enableSorting: enableSorting ?? false,

--- a/src/components/table/toolbar/table-view-options-dropdown.tsx
+++ b/src/components/table/toolbar/table-view-options-dropdown.tsx
@@ -11,6 +11,7 @@ import {
     DropdownMenuLabel,
     DropdownMenuSeparator,
 } from "../../../ui";
+import { useMemo } from "react";
 
 interface DataTableViewOptionsProps<TData> {
     table: Table<TData>;
@@ -19,6 +20,16 @@ interface DataTableViewOptionsProps<TData> {
 export function DataTableViewOptions<TData>({
     table,
 }: DataTableViewOptionsProps<TData>) {
+    const columns = useMemo(() => {
+        return table
+            .getAllColumns()
+            .filter(
+                (column) =>
+                    typeof column.accessorFn !== "undefined" &&
+                    column.getCanHide(),
+            );
+    }, []);
+
     return (
         <DropdownMenu>
             <DropdownMenuTrigger asChild>
@@ -34,27 +45,20 @@ export function DataTableViewOptions<TData>({
             <DropdownMenuContent align="end" className="w-[150px]">
                 <DropdownMenuLabel>Toggle columns</DropdownMenuLabel>
                 <DropdownMenuSeparator />
-                {table
-                    .getAllColumns()
-                    .filter(
-                        (column) =>
-                            typeof column.accessorFn !== "undefined" &&
-                            column.getCanHide(),
-                    )
-                    .map((column) => {
-                        return (
-                            <DropdownMenuCheckboxItem
-                                key={column.id}
-                                className="capitalize"
-                                checked={column.getIsVisible()}
-                                onCheckedChange={(value) =>
-                                    column.toggleVisibility(!!value)
-                                }
-                            >
-                                {column.id}
-                            </DropdownMenuCheckboxItem>
-                        );
-                    })}
+                {columns.map((column) => {
+                    return (
+                        <DropdownMenuCheckboxItem
+                            key={column.id}
+                            className="capitalize"
+                            checked={column.getIsVisible()}
+                            onCheckedChange={(value) =>
+                                column.toggleVisibility(!!value)
+                            }
+                        >
+                            {column.id}
+                        </DropdownMenuCheckboxItem>
+                    );
+                })}
             </DropdownMenuContent>
         </DropdownMenu>
     );


### PR DESCRIPTION
I defined accessorKey props in table components to id props in each component that uses accessorKey props.
The error here was that the components used in the table were using the id in the props as the key in the loop and creating duplicate components in visibility. This has been fixed.

![Screen Recording 2023-11-18 at 15 12 41](https://github.com/ferdiunal/refinedev-shadcn-ui/assets/5059851/de147c18-f595-4919-a156-0a23ee2ce886)
